### PR TITLE
Potential fix for code scanning alert no. 90: Useless assignment to local variable

### DIFF
--- a/src/components/EditJobCard.tsx
+++ b/src/components/EditJobCard.tsx
@@ -92,7 +92,7 @@ export default function EditJobCard({ job,formData, setFormData, handleEdit,
 
 
   const onSave = async () => {
-    let result = true;
+    let result;
     try {
       result = handleEdit ? await Promise.resolve(handleEdit()) : true;
     } catch (err) {


### PR DESCRIPTION
Potential fix for [https://github.com/CPSKJobConnect/CPSK-Job-Connect/security/code-scanning/90](https://github.com/CPSKJobConnect/CPSK-Job-Connect/security/code-scanning/90)

To fix this issue, the initializer assignment for `result` in the `onSave` function should be removed. Change `let result = true;` to simply `let result;`, as `result` will be assigned a value before its first use, regardless of the control flow. Only line 95 within the `onSave` function, in `src/components/EditJobCard.tsx`, needs to be changed. No extra imports or definitions are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
